### PR TITLE
Switch to ubuntu

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -2,7 +2,7 @@ FROM webhippie/ubuntu:18.04
 
 LABEL maintainer="Thomas Boerger <thomas@webhippie.de>" \
   org.label-schema.name="MongoDB" \
-  org.label-schema.vcs-url="https://github.com/dockhippie/mongodb.git" \
+  org.label-schema.version="latest" \
   org.label-schema.vendor="Thomas Boerger" \
   org.label-schema.schema-version="1.0"
 
@@ -15,12 +15,14 @@ CMD ["/bin/s6-svscan", "/etc/s6"]
 
 ENV CRON_ENABLED true
 
-RUN apt-get update && \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 && \
+  echo "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | tee /etc/apt/sources.list.d/mongodb.list && \
+  apt-get update && \
   apt-get upgrade -y && \
   mkdir -p /var/lib/mongodb && \
   groupadd -g 1000 mongodb && \
   useradd -u 1000 -d /var/lib/mongodb -g mongodb -s /bin/bash -m mongodb && \
-  apt-get install -y mongodb mongodb-clients jq && \
+  apt-get install -y mongodb-org jq && \
   apt-get autoremove -y && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/* /var/lib/mongodb/*

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM webhippie/alpine:latest
+FROM webhippie/ubuntu:18.04
 
 LABEL maintainer="Thomas Boerger <thomas@webhippie.de>" \
   org.label-schema.name="MongoDB" \
@@ -15,12 +15,14 @@ CMD ["/bin/s6-svscan", "/etc/s6"]
 
 ENV CRON_ENABLED true
 
-RUN apk update && \
-  apk upgrade && \
+RUN apt-get update && \
+  apt-get upgrade -y && \
   mkdir -p /var/lib/mongodb && \
   groupadd -g 1000 mongodb && \
   useradd -u 1000 -d /var/lib/mongodb -g mongodb -s /bin/bash -m mongodb && \
-  apk add mongodb mongodb-tools jq && \
-  rm -rf /var/cache/apk/* /var/lib/mongodb/*
+  apt-get install -y mongodb mongodb-clients jq && \
+  apt-get autoremove -y && \
+  apt-get clean -y && \
+  rm -rf /var/lib/apt/lists/* /var/lib/mongodb/*
 
 COPY ./overlay ./overlay-amd64 /

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -2,7 +2,7 @@ FROM webhippie/ubuntu:16.04-arm32v7
 
 LABEL maintainer="Thomas Boerger <thomas@webhippie.de>" \
   org.label-schema.name="MongoDB" \
-  org.label-schema.vcs-url="https://github.com/dockhippie/mongodb.git" \
+  org.label-schema.version="latest" \
   org.label-schema.vendor="Thomas Boerger" \
   org.label-schema.schema-version="1.0"
 

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -2,7 +2,7 @@ FROM webhippie/ubuntu:16.04-arm64v8
 
 LABEL maintainer="Thomas Boerger <thomas@webhippie.de>" \
   org.label-schema.name="MongoDB" \
-  org.label-schema.vcs-url="https://github.com/dockhippie/mongodb.git" \
+  org.label-schema.version="latest" \
   org.label-schema.vendor="Thomas Boerger" \
   org.label-schema.schema-version="1.0"
 


### PR DESCRIPTION
Since Alpine has dropped mongodb because of the license change we got to
use ubuntu now.