### PR TITLE
Fix backup script handling

### DIFF
--- a/latest/overlay/usr/bin/backup
+++ b/latest/overlay/usr/bin/backup
@@ -26,7 +26,7 @@ then
   )
 fi
 
-DATABASES=$(mongo ${ARGS[@]} --eval 'db.adminCommand( { listDatabases: 1, nameOnly: true } )' | jq -r .databases[].name | grep -v -E "(admin|local)")
+DATABASES=$(mongo ${ARGS[@]} --eval 'JSON.stringify(db.adminCommand( { listDatabases: 1, nameOnly: true } ))' | jq -r .databases[].name | grep -v -E "(admin|local)")
 MAXIMUM=14
 
 if [ "${DATABASES}" == "" ]


### PR DESCRIPTION
Until today jq was not able to parse the list of available databases,
with this fix mongo prints proper json which can be parsed correctly by
jq to fix the backup script.